### PR TITLE
v0.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 auth*.py
+statbot.db
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Invoke the bot in a monitored subreddit by including the bot's reddit username i
 
 Include a command, subject, and qualifier as needed, and the bot will reply with the requested data.
 
+Downvoted replies will be deleted automatically.
+
 ## Commands
 
 ### help
@@ -110,4 +112,4 @@ Example: `botname winprob {phi}`
 
 ## Copyright Notice
 
-This project uses the MLB-StatsAPI and PRAW packages to interface with the MLB and Reddit APIs. Use of MLB data is subject to the notice posted at http://gdx.mlb.com/components/copyright.txt.
+This package and its author are not affiliated with MLB or any MLB team. This project uses the MLB-StatsAPI and PRAW packages to interface with the MLB and Reddit APIs. Use of MLB data is subject to the notice posted at http://gdx.mlb.com/components/copyright.txt.

--- a/statbot/main.py
+++ b/statbot/main.py
@@ -23,6 +23,7 @@ import statsapi
 import praw
 import os
 import sqlite3
+import requests
 
 class StatBot:
     def __init__(self,sub):
@@ -301,8 +302,6 @@ class StatBot:
         players = statsapi.lookup_player(keyword)
         if len(players): return players[0]['id']
         else:
-            print('Looking up player from alternate MLB source...')
-            import requests
             r = requests.get('http://lookup-service-prod.mlb.com/json/named.search_player_all.bam?sport_code=%27mlb%27&name_part=%27{}%25%27'.format(keyword))
             if r.status_code not in [200,201]:
                 print('Error looking up player from alternate MLB source. Status code: {}.'.format(r.status_code))

--- a/statbot/main.py
+++ b/statbot/main.py
@@ -213,7 +213,7 @@ class StatBot:
                         if replyText != '': replyText += '\n\n*****\n\n'
                         try:
                             who = statsapi.lookup_team(comment.body[comment.body.find('{')+1:comment.body.find('}')])[0]['id']
-                            game = statsapi.schedule(date=datetime.today().strftime('%m/%d/%Y'),team=who)[0]
+                            game = statsapi.schedule(team=who)[0]
                             contextMetrics = statsapi.get('game_contextMetrics',{'gamePk':game['game_id']})
                             away_win_prob = contextMetrics.get('awayWinProbability','-')
                             home_win_prob = contextMetrics.get('homeWinProbability','-')
@@ -234,12 +234,12 @@ class StatBot:
                                     gamePks += '{},'.format(i)
                                 if len(gamePks):
                                     if gamePks[-1] == ',': gamePks = gamePks[:-1]
-                                games = statsapi.schedule(date=datetime.today().strftime('%m/%d/%Y'),game_id=gamePks)
+                                games = statsapi.schedule(game_id=gamePks)
                                 for game in games:
                                     replyText += '\n    ' + game['summary']
                             else:
                                 who = statsapi.lookup_team(comment.body[comment.body.find('{')+1:comment.body.find('}')])[0]['id']
-                                game = statsapi.schedule(date=datetime.today().strftime('%m/%d/%Y'),team=who)
+                                game = statsapi.schedule(team=who)
                                 replyText += game[0]['summary']
                         except Exception as e:
                             print('Error generating response for score: {}'.format(e))

--- a/statbot/main.py
+++ b/statbot/main.py
@@ -294,6 +294,22 @@ class StatBot:
 
         return
 
+    def lookup_player(self, keyword):
+        """Check statsapi.lookup_player() and if no results, try other MLB source.
+        Stats API only returns active players.
+        """
+        players = statsapi.lookup_player(keyword)
+        if len(players): return players[0]['id']
+        else:
+            print('Looking up player from alternate MLB source...')
+            import requests
+            r = requests.get('http://lookup-service-prod.mlb.com/json/named.search_player_all.bam?sport_code=%27mlb%27&name_part=%27{}%25%27'.format(keyword))
+            if r.status_code not in [200,201]:
+                print('Error looking up player from alternate MLB source. Status code: {}.'.format(r.status_code))
+                return ''
+            else:
+                return r.json()['search_player_all']['queryResults']['row']['player_id'] if r.json()['search_player_all']['queryResults']['totalSize']=='1' else r.json()['search_player_all']['queryResults']['row'][0]['player_id']
+
 if __name__=='__main__':
     if len(sys.argv)>1:
         sub = sys.argv[1]

--- a/statbot/main.py
+++ b/statbot/main.py
@@ -173,7 +173,7 @@ class StatBot:
                         self.comments[comment.id]['cmd'].append('careerstats')
                         if replyText != '': replyText += '\n\n*****\n\n'
                         try:
-                            who = statsapi.lookup_player(comment.body[comment.body.find('{')+1:comment.body.find('}')])[0]['id']
+                            who = self.lookup_player(comment.body[comment.body.find('{')+1:comment.body.find('}')])
                             what = []
                             if 'hitting' in comment.body.lower() or 'batting' in comment.body.lower(): what.append('hitting')
                             if 'pitching' in comment.body.lower(): what.append('pitching')

--- a/statbot/main.py
+++ b/statbot/main.py
@@ -140,7 +140,7 @@ class StatBot:
                     continue
                 replyText = ''
                 if str(self.r.user.me()).lower() in comment.body.lower() and comment.author != self.r.user.me():
-                    self.comments.update({comment.id : {'sub' : comment.subreddit, 'author' : comment.author, 'post' : comment.submission, 'date' : datetime.now(), 'cmd' : [], 'errors' : []}})
+                    self.comments.update({comment.id : {'sub' : comment.subreddit, 'author' : comment.author, 'post' : comment.submission, 'date' : time.time(), 'cmd' : [], 'errors' : []}})
                     self.dbc.execute("insert or ignore into comments (comment_id, sub, author, post, date) values (?, ?, ?, ?, ?);", (str(comment.id), str(comment.subreddit), str(comment.author), str(comment.submission), str(comment.created_utc)))
                     print('({}) {} - {}: {}'.format(comment.subreddit, comment.id, comment.author, comment.body))
                     if 'help' in comment.body.lower():
@@ -285,7 +285,7 @@ class StatBot:
                     print('Deleting comment {} with score ({}) at or below threshold ({})...'.format(self.comments[x]['reply'], self.comments[x]['reply'].score, self.del_threshold))
                     try:
                         self.comments[x]['reply'].delete()
-                        self.comments[x].update({'removed':datetime.now()})
+                        self.comments[x].update({'removed':time.time()})
                         self.dbc.execute("update comments set removed=? where comment_id=?;", (str(self.comments[x].get('removed')), str(x)))
                     except Exception as e:
                         print('Error deleting downvoted comment: {}'.format(e))

--- a/statbot/version.py
+++ b/statbot/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-VERSION = '0.0.1'
+VERSION = '0.0.2'


### PR DESCRIPTION
* Delete downvoted comments (at or below configurable threshold of -2)
* Keep track of processed comments to avoid duplicate replies
* FIX: Don't include date when looking up game info for score and winprob commands; otherwise tomorrow's game will be returned when it's after 12am ET (#1)
* FIX: Look up player from alternate source if not found in MLB StatsAPI lookup. This allows the careerstats command to work on inactive players.